### PR TITLE
Select moderation requests from changelist for publishing

### DIFF
--- a/djangocms_moderation/admin.py
+++ b/djangocms_moderation/admin.py
@@ -511,6 +511,14 @@ class ModerationRequestAdmin(admin.ModelAdmin):
         treenodes = self._get_selected_tree_nodes(request)
         redirect_url = self._redirect_to_changeview_url(collection_id)
 
+        try:
+            collection = ModerationCollection.objects.get(id=int(collection_id))
+        except (ValueError, ModerationCollection.DoesNotExist):
+            raise Http404
+
+        if collection.author != request.user:
+            raise PermissionDenied
+
         if request.method != 'POST':
             context = self._custom_view_context(request)
             return render(
@@ -519,10 +527,6 @@ class ModerationRequestAdmin(admin.ModelAdmin):
                 context
             )
         else:
-            try:
-                collection = ModerationCollection.objects.get(id=int(collection_id))
-            except (ValueError, ModerationCollection.DoesNotExist):
-                raise Http404
             resubmitted_requests = []
 
             for node in treenodes.all():
@@ -566,6 +570,14 @@ class ModerationRequestAdmin(admin.ModelAdmin):
         treenodes = self._get_selected_tree_nodes(request)
         redirect_url = self._redirect_to_changeview_url(collection_id)
 
+        try:
+            collection = ModerationCollection.objects.get(id=int(collection_id))
+        except (ValueError, ModerationCollection.DoesNotExist):
+            raise Http404
+
+        if request.user != collection.author:
+            raise PermissionDenied
+
         if request.method != 'POST':
             context = self._custom_view_context(request)
             return render(
@@ -574,11 +586,6 @@ class ModerationRequestAdmin(admin.ModelAdmin):
                 context,
             )
         else:
-            try:
-                collection = ModerationCollection.objects.get(id=int(collection_id))
-            except (ValueError, ModerationCollection.DoesNotExist):
-                raise Http404
-
             num_published_requests = 0
             for node in treenodes.all():
                 mr = node.moderation_request

--- a/djangocms_moderation/admin.py
+++ b/djangocms_moderation/admin.py
@@ -496,17 +496,23 @@ class ModerationRequestAdmin(admin.ModelAdmin):
         ).select_related('moderation_request')
         return treenodes
 
+    def _custom_view_context(self, request):
+        treenodes = self._get_selected_tree_nodes(request)
+        collection_id = request.GET.get('collection_id')
+        redirect_url = self._redirect_to_changeview_url(collection_id)
+        return dict(
+            ids=request.GET.getlist("ids"),
+            back_url=redirect_url,
+            queryset=[n.moderation_request for n in treenodes]
+        )
+
     def resubmit_view(self, request):
         collection_id = request.GET.get('collection_id')
         treenodes = self._get_selected_tree_nodes(request)
         redirect_url = self._redirect_to_changeview_url(collection_id)
 
         if request.method != 'POST':
-            context = dict(
-                ids=request.GET.getlist("ids"),
-                back_url=redirect_url,
-                queryset=[n.moderation_request for n in treenodes]
-            )
+            context = self._custom_view_context(request)
             return render(
                 request,
                 'admin/djangocms_moderation/moderationrequest/resubmit_confirmation.html',
@@ -561,11 +567,7 @@ class ModerationRequestAdmin(admin.ModelAdmin):
         redirect_url = self._redirect_to_changeview_url(collection_id)
 
         if request.method != 'POST':
-            context = dict(
-                ids=request.GET.getlist("ids"),
-                back_url=redirect_url,
-                queryset=[n.moderation_request for n in treenodes],
-            )
+            context = self._custom_view_context(request)
             return render(
                 request,
                 "admin/djangocms_moderation/moderationrequest/publish_confirmation.html",
@@ -610,11 +612,7 @@ class ModerationRequestAdmin(admin.ModelAdmin):
         redirect_url = self._redirect_to_changeview_url(collection_id)
 
         if request.method != 'POST':
-            context = dict(
-                ids=request.GET.getlist("ids"),
-                back_url=redirect_url,
-                queryset=[n.moderation_request for n in treenodes]
-            )
+            context = self._custom_view_context(request)
             return render(
                 request,
                 "admin/djangocms_moderation/moderationrequest/rework_confirmation.html",
@@ -663,11 +661,7 @@ class ModerationRequestAdmin(admin.ModelAdmin):
         redirect_url = self._redirect_to_changeview_url(collection_id)
 
         if request.method != 'POST':
-            context = dict(
-                ids=request.GET.getlist("ids"),
-                back_url=redirect_url,
-                queryset=[n.moderation_request for n in treenodes]
-            )
+            context = self._custom_view_context(request)
             return render(
                 request,
                 "admin/djangocms_moderation/moderationrequest/approve_confirmation.html",

--- a/tests/test_admin_actions.py
+++ b/tests/test_admin_actions.py
@@ -1,6 +1,8 @@
 import mock
+import unittest
 
 from django.contrib.admin import ACTION_CHECKBOX_NAME
+from django.contrib.auth.models import Group
 from django.test import TransactionTestCase
 from django.urls import reverse
 
@@ -8,296 +10,913 @@ from cms.test_utils.testcases import CMSTestCase
 
 from djangocms_versioning.constants import DRAFT, PUBLISHED
 from djangocms_versioning.models import Version
-from djangocms_versioning.test_utils.factories import PageVersionFactory
 
 from djangocms_moderation import constants
 from djangocms_moderation.admin import ModerationRequestTreeAdmin
 from djangocms_moderation.constants import ACTION_REJECTED
 from djangocms_moderation.models import (
-    ModerationCollection,
     ModerationRequest,
     ModerationRequestTreeNode,
     Role,
-    Workflow,
 )
 
 from .utils import factories
-from .utils.base import BaseTestCase
 
 
-class AdminActionTest(BaseTestCase):
+def get_url_data(cls, action):
+    get_resp = cls.client.get(cls.url)
+    data = {
+        "action": action,
+        ACTION_CHECKBOX_NAME: [str(f.pk) for f in get_resp.context['cl'].queryset]
+    }
+    return data
+
+
+class ApproveSelectedTest(CMSTestCase):
 
     def setUp(self):
-        self.wf = Workflow.objects.create(name="Workflow Test")
-        self.collection = ModerationCollection.objects.create(
-            author=self.user,
-            name="Collection Admin Actions",
-            workflow=self.wf,
-            status=constants.IN_REVIEW,
-        )
-
-        pg1_version = PageVersionFactory()
-        pg2_version = PageVersionFactory()
-
-        self.mr1 = ModerationRequest.objects.create(
-            version=pg1_version, language="en", collection=self.collection,
-            is_active=True, author=self.collection.author
-        )
-
-        self.wfst1 = self.wf.steps.create(role=self.role1, is_required=True, order=1)
-        self.wfst2 = self.wf.steps.create(role=self.role2, is_required=True, order=1)
-
-        # this moderation request is approved
-        self.mr1.actions.create(by_user=self.user, action=constants.ACTION_STARTED)
-        self.mr1.update_status(constants.ACTION_APPROVED, self.user)
-        self.mr1.update_status(constants.ACTION_APPROVED, self.user2)
-
-        # this moderation request is not approved
-        self.mr2 = ModerationRequest.objects.create(
-            version=pg2_version, language="en", collection=self.collection,
-            is_active=True, author=self.collection.author
-        )
-        self.mr2.actions.create(by_user=self.user, action=constants.ACTION_STARTED)
-
+        # Set up the db data
+        self.role1 = Role.objects.create(name="Role 1", user=factories.UserFactory(is_staff=True, is_superuser=True))
+        self.role2 = Role.objects.create(name="Role 2", user=factories.UserFactory(is_staff=True, is_superuser=True))
+        self.collection = factories.ModerationCollectionFactory(
+            author=self.role1.user, status=constants.IN_REVIEW)
+        self.collection.workflow.steps.create(role=self.role1, is_required=True, order=1)
+        self.collection.workflow.steps.create(role=self.role2, is_required=True, order=1)
+        # NOTE: Setting ids because we want the ids of the requests to be
+        # different to the ids of the nodes. This will give us confidence
+        # that the ids of the correct objects are being passed to the
+        # correct places.
+        self.moderation_request1 = factories.ModerationRequestFactory(
+            id=1, collection=self.collection)
+        self.moderation_request2 = factories.ModerationRequestFactory(
+            id=2, collection=self.collection)
         self.root1 = factories.RootModerationRequestTreeNodeFactory(
-            moderation_request=self.mr1
-        )
+            id=4, moderation_request=self.moderation_request1)
+        factories.ChildModerationRequestTreeNodeFactory(
+            id=5, moderation_request=self.moderation_request2, parent=self.root1)
         self.root2 = factories.RootModerationRequestTreeNodeFactory(
-            moderation_request=self.mr2
-        )
+            id=6, moderation_request=self.moderation_request2)
+        # Request 1 is approved, request 2 is started
+        self.moderation_request1.actions.create(by_user=self.role1.user, action=constants.ACTION_STARTED)
+        self.moderation_request2.actions.create(by_user=self.role1.user, action=constants.ACTION_STARTED)
+        self.moderation_request1.update_status(constants.ACTION_APPROVED, self.role1.user)
+        self.moderation_request1.update_status(constants.ACTION_APPROVED, self.role2.user)
 
+        # Set up the url data
         self.url = reverse("admin:djangocms_moderation_moderationrequesttreenode_changelist")
-        self.url_with_filter = "{}?moderation_request__collection__id={}".format(
-            self.url, self.collection.pk
-        )
+        self.url += "?moderation_request__collection__id={}".format(self.collection.pk)
 
-        self.client.force_login(self.user)
+        # Asserts to check data set up is ok. Ideally wouldn't need them, but
+        # the set up is so complex that it's safer to have them.
+        self.assertFalse(self.moderation_request2.is_approved())
+        self.assertTrue(self.moderation_request1.is_approved())
 
-    def test_publish_selected(self):
-        # Pre-checks
-        version1 = self.mr1.version
-        version2 = self.mr2.version
-        self.assertTrue(self.mr1.is_active)
-        self.assertTrue(self.mr2.is_active)
-        self.assertEqual(version1.state, DRAFT)
-        self.assertEqual(version2.state, DRAFT)
-
-        # first get selected moderation requests from the moderation request changelist
-        get_resp = self.client.get(self.url_with_filter)
-        data = {
-            "action": "publish_selected",
-            ACTION_CHECKBOX_NAME: [str(f.pk) for f in get_resp.context['cl'].queryset]
-        }
-        response = self.client.post(self.url_with_filter, data)
-        self.client.post(response.url)
-        # After-checks
-        # We can't do refresh_from_db() for Version, as it complains about
-        # `state` field being changed directly
-        version1 = Version.objects.get(pk=version1.pk)
-        version2 = Version.objects.get(pk=version2.pk)
-        self.mr1.refresh_from_db()
-        self.mr2.refresh_from_db()
-
-        self.assertEqual(version1.state, PUBLISHED)
-        self.assertEqual(version2.state, DRAFT)
-        self.assertFalse(self.mr1.is_active)
-        self.assertTrue(self.mr2.is_active)
-
+    @mock.patch("django.contrib.messages.success")
     @mock.patch("djangocms_moderation.admin.notify_collection_moderators")
     @mock.patch("djangocms_moderation.admin.notify_collection_author")
-    def test_approve_selected(self, notify_author_mock, notify_moderators_mock):
-        self.assertFalse(self.mr2.is_approved())
-        self.assertTrue(self.mr1.is_approved())
+    def test_approve_selected(self, notify_author_mock, notify_moderators_mock, messages_mock):
+        # Login as the collection author/role 1
+        self.client.force_login(self.role1.user)
 
-        get_resp = self.client.get(self.url_with_filter)
-        data = {
-            "action": "approve_selected",
-            ACTION_CHECKBOX_NAME: [str(f.pk) for f in get_resp.context['cl'].queryset]
-        }
-        response = self.client.post(self.url_with_filter, data)
-        self.client.post(response.url)
+        # Select the approve action from the menu
+        data = get_url_data(self, "approve_selected")
+        response = self.client.post(self.url, data)
+        # And now go to the view the action redirects to. This will
+        # perform step1 of the approval process (as defined in the
+        # workflow in the setUp method)
+        response = self.client.post(response.url)
 
+        # Check response
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(messages_mock.call_args[0][1], '1 request successfully approved')
+        messages_mock.reset_mock()
+
+        # Check correct users notified
         notify_author_mock.assert_called_once_with(
             collection=self.collection,
-            moderation_requests=[self.mr2],
-            action=self.mr2.get_last_action().action,
-            by_user=self.user,
+            moderation_requests=[self.moderation_request2],
+            action=self.moderation_request2.get_last_action().action,
+            by_user=self.role1.user,
         )
-
         notify_moderators_mock.assert_called_once_with(
             collection=self.collection,
-            moderation_requests=[self.mr2],
-            action_obj=self.mr2.get_last_action(),
+            moderation_requests=[self.moderation_request2],
+            action_obj=self.moderation_request2.get_last_action(),
         )
+        # And reset mocks because we'll be needing to check this again
+        # for step2
         notify_author_mock.reset_mock()
         notify_moderators_mock.reset_mock()
 
-        # There are 2 steps so we need to approve both to get mr2 approved
-        self.assertFalse(self.mr2.is_approved())
-        self.assertTrue(self.mr1.is_approved())
+        # The status of the moderation requests hasn't changed yet
+        # because there are 2 steps to approval and both are needed
+        # for status to change
+        self.assertFalse(self.moderation_request2.is_approved())
+        self.assertTrue(self.moderation_request1.is_approved())
+
+        # Collection status hasn't changed either
         self.collection.refresh_from_db()
         self.assertEqual(self.collection.status, constants.IN_REVIEW)
 
-        self.client.force_login(self.user2)
-        response = self.client.post(self.url_with_filter, data)
-        self.client.post(response.url)
+        # Now login as the user responsible for approving step2
+        self.client.force_login(self.role2.user)
 
-        self.assertTrue(self.mr2.is_approved())
-        self.assertTrue(self.mr1.is_approved())
+        # Select the approve action from the menu again
+        data = get_url_data(self, "approve_selected")
+        response = self.client.post(self.url, data)
+        # And now go to the view the action redirects to. This will
+        # perform step2 of the approval process (as defined in the
+        # workflow in the setUp method)
+        response = self.client.post(response.url)
+
+        # Check response
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(messages_mock.call_args[0][1], '1 request successfully approved')
+
+        # The status of the previously unapproved request has changed.
+        # The other request stays as it is
+        self.assertTrue(self.moderation_request2.is_approved())
+        self.assertTrue(self.moderation_request1.is_approved())
+
+        # The collection has been archived as both requests have been
+        # approved now
         self.collection.refresh_from_db()
         self.assertEqual(self.collection.status, constants.ARCHIVED)
 
+        # Correct users have been notified
         notify_author_mock.assert_called_once_with(
             collection=self.collection,
-            moderation_requests=[self.mr2],
-            action=self.mr2.get_last_action().action,
-            by_user=self.user2,
+            moderation_requests=[self.moderation_request2],
+            action=self.moderation_request2.get_last_action().action,
+            by_user=self.role2.user,
         )
         self.assertFalse(notify_moderators_mock.called)
 
+    @mock.patch("django.contrib.messages.success")
     @mock.patch("djangocms_moderation.admin.notify_collection_moderators")
-    @mock.patch("djangocms_moderation.admin.notify_collection_author")
-    def test_reject_selected(self, notify_author_mock, notify_moderators_mock):
-        self.assertFalse(self.mr2.is_approved())
-        self.assertFalse(self.mr2.is_rejected())
-        self.assertTrue(self.mr1.is_approved())
-
-        get_resp = self.client.get(self.url_with_filter)
-        data = {
-            "action": "reject_selected",
-            ACTION_CHECKBOX_NAME: [str(f.pk) for f in get_resp.context['cl'].queryset]
-        }
-        response = self.client.post(self.url_with_filter, data)
-        self.client.post(response.url)
-
-        self.assertFalse(self.mr2.is_approved())
-        self.assertTrue(self.mr2.is_rejected())
-        self.assertTrue(self.mr1.is_approved())
-
-        self.assertFalse(notify_moderators_mock.called)
-
-        notify_author_mock.assert_called_once_with(
-            collection=self.collection,
-            moderation_requests=[self.mr2],
-            action=self.mr2.get_last_action().action,
-            by_user=self.user,
+    def test_approve_selected_sends_correct_emails_to_moderators(self, notify_moderators_mock, messages_mock):
+        # Set up additional roles and user
+        user3 = factories.UserFactory(is_staff=True, is_superuser=True)
+        group = Group.objects.create(name="Group 1")
+        user3.groups.add(group)
+        role3 = Role.objects.create(name="Role 3", group=group)
+        role4 = Role.objects.create(user=self.role1.user)
+        # Set up two more steps
+        self.collection.workflow.steps.create(role=role3, is_required=True, order=1)
+        self.collection.workflow.steps.create(role=role4, is_required=True, order=1)
+        self.role1.user.groups.add(group)
+        # Set up one more, partially approved request
+        moderation_request3 = factories.ModerationRequestFactory(id=3, collection=self.collection)
+        moderation_request3.actions.create(by_user=self.role1.user, action=constants.ACTION_STARTED)
+        moderation_request3.update_status(by_user=self.role1.user, action=constants.ACTION_APPROVED)
+        moderation_request3.update_status(by_user=self.role2.user, action=constants.ACTION_APPROVED)
+        factories.RootModerationRequestTreeNodeFactory(
+            id=7, moderation_request=moderation_request3
         )
 
-        self.collection.refresh_from_db()
-        self.assertEqual(self.collection.status, constants.IN_REVIEW)
+        # Login as the collection author/role1 user
+        self.client.force_login(self.role1.user)
+        data = get_url_data(self, "approve_selected")
+        response = self.client.post(self.url, data)
+        response = self.client.post(response.url)
 
-    @mock.patch("djangocms_moderation.admin.notify_collection_moderators")
-    @mock.patch("djangocms_moderation.admin.notify_collection_author")
-    def test_resubmit_selected(self, notify_author_mock, notify_moderators_mock):
-        self.mr2.update_status(
-            action=ACTION_REJECTED,
-            by_user=self.user
-        )
-        self.assertTrue(self.mr2.is_rejected())
-        self.assertTrue(self.mr1.is_approved())
+        # Check response
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(messages_mock.call_args[0][1], '3 requests successfully approved')
+        messages_mock.reset_mock()
 
-        get_resp = self.client.get(self.url_with_filter)
-        data = {
-            "action": "resubmit_selected",
-            ACTION_CHECKBOX_NAME: [str(f.pk) for f in get_resp.context['cl'].queryset]
-        }
-        response = self.client.post(self.url_with_filter, data)
-        self.client.post(response.url)
-
-        self.assertFalse(self.mr2.is_rejected())
-        self.assertTrue(self.mr1.is_approved())
-
-        self.assertFalse(notify_author_mock.called)
-        notify_moderators_mock.assert_called_once_with(
-            collection=self.collection,
-            moderation_requests=[self.mr2],
-            action_obj=self.mr2.get_last_action(),
-        )
-
-        self.collection.refresh_from_db()
-        self.assertEqual(self.collection.status, constants.IN_REVIEW)
-
-    @mock.patch("djangocms_moderation.admin.notify_collection_moderators")
-    def test_approve_selected_sends_correct_emails(self, notify_moderators_mock):
-        role4 = Role.objects.create(user=self.user)
-        # Add two more steps
-        self.wf.steps.create(role=self.role3, is_required=True, order=1)
-        self.wf.steps.create(role=role4, is_required=True, order=1)
-        self.user.groups.add(self.group)
-
-        # Add one more, partially approved request
-        pg3_version = PageVersionFactory()
-        self.mr3 = ModerationRequest.objects.create(
-            version=pg3_version, language="en", collection=self.collection,
-            is_active=True, author=self.collection.author
-        )
-        self.root3 = factories.RootModerationRequestTreeNodeFactory(
-            moderation_request=self.mr3
-        )
-        self.mr3.actions.create(by_user=self.user, action=constants.ACTION_STARTED)
-        self.mr3.update_status(by_user=self.user, action=constants.ACTION_APPROVED)
-        self.mr3.update_status(by_user=self.user2, action=constants.ACTION_APPROVED)
-
-        self.user.groups.add(self.group)
-
-        fixtures = ModerationRequestTreeNode.objects.filter(
-            moderation_request__collection_id=self.collection.pk
-        )
-        data = {
-            "action": "approve_selected",
-            ACTION_CHECKBOX_NAME: [str(f.pk) for f in fixtures]
-        }
-
-        # First post as `self.user` should notify mr1 and mr2 and mr3 moderators
-        response = self.client.post(self.url_with_filter, data)
-        # The notify email will be send accordingly. As mr1 and mr3 are in the
+        # First post as role1 user should notify mr1 and mr2 and mr3 moderators
+        # The notify email will be sent accordingly. As mr1 and mr3 are in
         # different stages of approval compared to mr 2,
         # we need to send 2 emails to appropriate moderators
-        self.client.post(response.url)
         self.assertEqual(notify_moderators_mock.call_count, 2)
-        self.assertEqual(
-            notify_moderators_mock.call_args_list[0],
-            mock.call(collection=self.collection,
-                      moderation_requests=[self.mr1, self.mr3],
-                      action_obj=self.mr1.get_last_action()
-                      )
-        )
-
         self.assertEqual(
             notify_moderators_mock.call_args_list[1],
             mock.call(collection=self.collection,
-                      moderation_requests=[self.mr2],
-                      action_obj=self.mr2.get_last_action(),
-                      )
+                      moderation_requests=[self.moderation_request1, moderation_request3],
+                      action_obj=self.moderation_request1.get_last_action())
         )
-        self.assertFalse(self.mr1.is_approved())
-        self.assertFalse(self.mr3.is_approved())
-
+        self.assertEqual(
+            notify_moderators_mock.call_args_list[0],
+            mock.call(collection=self.collection,
+                      moderation_requests=[self.moderation_request2],
+                      action_obj=self.moderation_request2.get_last_action())
+        )
         notify_moderators_mock.reset_mock()
-        response = self.client.post(self.url_with_filter, data)
-        self.client.post(response.url)
+
+        # No moderation requests are approved yet
+        self.assertFalse(self.moderation_request1.is_approved())
+        self.assertFalse(self.moderation_request2.is_approved())
+        self.assertFalse(moderation_request3.is_approved())
+
+        response = self.client.post(self.url, data)
+        response = self.client.post(response.url)
+
+        # Check response
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(messages_mock.call_args[0][1], '2 requests successfully approved')
+        messages_mock.reset_mock()
+
         # Second post approves m3 and mr1, but as this is the last stage of
         # the approval, there is no need for notification emails anymore
         self.assertEqual(notify_moderators_mock.call_count, 0)
-        self.assertTrue(self.mr1.is_approved())
-        self.assertTrue(self.mr3.is_approved())
+        # moderation request 1 and 3 are now approved. Moderation request
+        # 2 is not
+        self.assertTrue(self.moderation_request1.is_approved())
+        self.assertFalse(self.moderation_request2.is_approved())
+        self.assertTrue(moderation_request3.is_approved())
 
-        self.client.force_login(self.user2)
-        # user2 can approve only 1 request, mr2, so one notification email
-        # should go out
-        response = self.client.post(self.url_with_filter, data)
-        self.client.post(response.url)
-        notify_moderators_mock.assert_called_once_with(
-            collection=self.collection,
-            moderation_requests=[self.mr2],
-            action_obj=self.mr2.get_last_action(),
-        )
-
-        self.user.groups.remove(self.group)
-
-        # Not all request have been fully approved
+        # moderation request 2 is not yet approved so collection should
+        # still be in review
         self.collection.refresh_from_db()
         self.assertEqual(self.collection.status, constants.IN_REVIEW)
+
+        self.client.force_login(self.role2.user)
+        # user2 can approve only 1 request, mr2, so one notification email
+        # should go out
+        response = self.client.post(self.url, data)
+        response = self.client.post(response.url)
+
+        # Check response
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(messages_mock.call_args[0][1], '1 request successfully approved')
+        messages_mock.reset_mock()
+
+        notify_moderators_mock.assert_called_once_with(
+            collection=self.collection,
+            moderation_requests=[self.moderation_request2],
+            action_obj=self.moderation_request2.get_last_action(),
+        )
+        notify_moderators_mock.reset_mock()
+
+        # moderation request 2 is still not yet approved
+        self.assertTrue(self.moderation_request1.is_approved())
+        self.assertFalse(self.moderation_request2.is_approved())
+        self.assertTrue(moderation_request3.is_approved())
+
+        # moderation request 2 is not yet approved so collection should
+        # still be in review
+        self.collection.refresh_from_db()
+        self.assertEqual(self.collection.status, constants.IN_REVIEW)
+
+        self.client.force_login(user3)
+        response = self.client.post(self.url, data)
+        response = self.client.post(response.url)
+
+        # Check response
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(messages_mock.call_args[0][1], '1 request successfully approved')
+        messages_mock.reset_mock()
+
+        notify_moderators_mock.assert_called_once_with(
+            collection=self.collection,
+            moderation_requests=[self.moderation_request2],
+            action_obj=self.moderation_request2.get_last_action(),
+        )
+        notify_moderators_mock.reset_mock()
+
+        self.assertTrue(self.moderation_request1.is_approved())
+        self.assertFalse(self.moderation_request2.is_approved())
+        self.assertTrue(moderation_request3.is_approved())
+
+        # moderation request 2 is not yet approved so collection should
+        # still be in review
+        self.collection.refresh_from_db()
+        self.assertEqual(self.collection.status, constants.IN_REVIEW)
+
+        self.client.force_login(self.role1.user)
+        response = self.client.post(self.url, data)
+        response = self.client.post(response.url)
+
+        # Check response
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(messages_mock.call_args[0][1], '1 request successfully approved')
+        messages_mock.reset_mock()
+
+        self.assertEqual(notify_moderators_mock.call_count, 0)
+
+        self.assertTrue(self.moderation_request1.is_approved())
+        self.assertTrue(self.moderation_request2.is_approved())
+        self.assertTrue(moderation_request3.is_approved())
+
+        # moderation request 2 is now approved so collection should
+        # have been archived
+        self.collection.refresh_from_db()
+        self.assertEqual(self.collection.status, constants.ARCHIVED)
+
+    def test_404_on_nonexisting_collection(self):
+        self.client.force_login(self.role1.user)
+        # Need to access the view directly to test for this
+        url = reverse("admin:djangocms_moderation_moderationrequest_approve")
+        url += "?ids=1,2&collection_id=12342"
+
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_404_on_invalid_collection_id(self):
+        self.client.force_login(self.role1.user)
+        # Need to access the view directly to test for this
+        url = reverse("admin:djangocms_moderation_moderationrequest_approve")
+        url += "?ids=1,2&collection_id=aaa"
+
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 404)
+
+    @mock.patch("djangocms_moderation.admin.notify_collection_moderators")
+    @mock.patch("django.contrib.messages.success")
+    @mock.patch(
+        "djangocms_moderation.models.ModerationRequest.user_can_take_moderation_action",
+        mock.Mock(return_value=False)
+    )
+    def test_view_doesnt_approve_when_user_cant_approve(self, messages_mock, notify_moderators_mock):
+        self.client.force_login(self.role1.user)
+        # Set up the url (need to access the view directly)
+        url = reverse("admin:djangocms_moderation_moderationrequest_approve")
+        url += "?ids=%d,%d&collection_id=%d" % (
+            self.moderation_request1.pk, self.moderation_request2.pk, self.collection.pk)
+
+        response = self.client.post(url)
+
+        # Check response
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(messages_mock.call_args[0][1], '0 requests successfully approved')
+        # No actions were approved
+        self.assertFalse(self.moderation_request2.actions.filter(
+            action=constants.ACTION_RESUBMITTED).exists())
+        self.assertEqual(notify_moderators_mock.call_count, 0)
+
+    def test_approve_view_when_using_get(self):
+        self.client.force_login(self.role1.user)
+        # Choose the approve_selected action from the dropdown
+        data = get_url_data(self, "approve_selected")
+        response = self.client.post(self.url, data)
+        # And follow the redirect (with a GET call) to the view that does the approve
+        response = self.client.get(response.url)
+
+        # Smoke test the response. When using a GET call not a lot happens.
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.templates[0].name,
+            'admin/djangocms_moderation/moderationrequest/approve_confirmation.html'
+        )
+
+
+class RejectSelectedTest(CMSTestCase):
+
+    def setUp(self):
+        # Set up the db data
+        self.user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.collection = factories.ModerationCollectionFactory(
+            author=self.user, status=constants.IN_REVIEW)
+        self.role1 = Role.objects.create(name="Role 1", user=self.user)
+        self.role2 = Role.objects.create(name="Role 2", user=factories.UserFactory(is_staff=True, is_superuser=True))
+        self.collection.workflow.steps.create(role=self.role1, is_required=True, order=1)
+        self.collection.workflow.steps.create(role=self.role2, is_required=True, order=1)
+        # NOTE: Setting ids because we want the ids of the requests to be
+        # different to the ids of the nodes. This will give us confidence
+        # that the ids of the correct objects are being passed to the
+        # correct places.
+        self.moderation_request1 = factories.ModerationRequestFactory(
+            id=1, collection=self.collection)
+        self.moderation_request2 = factories.ModerationRequestFactory(
+            id=2, collection=self.collection)
+        self.root1 = factories.RootModerationRequestTreeNodeFactory(
+            id=4, moderation_request=self.moderation_request1)
+        factories.ChildModerationRequestTreeNodeFactory(
+            id=5, moderation_request=self.moderation_request2, parent=self.root1)
+        self.root2 = factories.RootModerationRequestTreeNodeFactory(
+            id=6, moderation_request=self.moderation_request2)
+        # Request 1 is approved, request 2 is started
+        self.moderation_request1.actions.create(by_user=self.user, action=constants.ACTION_STARTED)
+        self.moderation_request2.actions.create(by_user=self.user, action=constants.ACTION_STARTED)
+        self.moderation_request1.update_status(constants.ACTION_APPROVED, self.role1.user)
+        self.moderation_request1.update_status(constants.ACTION_APPROVED, self.role2.user)
+
+        # Login as the collection author
+        self.client.force_login(self.user)
+
+        # Set up the url data
+        self.url = reverse("admin:djangocms_moderation_moderationrequesttreenode_changelist")
+        self.url += "?moderation_request__collection__id={}".format(self.collection.pk)
+
+        # Asserts to check data set up is ok. Ideally wouldn't need them, but
+        # the set up is so complex that it's safer to have them.
+        self.assertFalse(self.moderation_request2.is_approved())
+        self.assertFalse(self.moderation_request2.is_rejected())
+        self.assertTrue(self.moderation_request2.is_active)
+        self.assertFalse(self.moderation_request2.actions.get().is_archived)
+        self.assertTrue(self.moderation_request1.is_approved())
+
+    @mock.patch("django.contrib.messages.success")
+    @mock.patch("djangocms_moderation.admin.notify_collection_moderators")
+    @mock.patch("djangocms_moderation.admin.notify_collection_author")
+    def test_reject_selected_rejects_request(self, notify_author_mock, notify_moderators_mock, messages_mock):
+        # Select the reject action from the menu
+        data = get_url_data(self, "reject_selected")
+        response = self.client.post(self.url, data)
+        # And now go to the view the action redirects to
+        response = self.client.post(response.url)
+
+        # Response is correct
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(
+            messages_mock.call_args[0][1],
+            '1 request successfully submitted for rework'
+        )
+
+        # The rejected request has indeed been marked rejected. The
+        # previous action on the rejected request has been archived. The
+        # previously approved request has not changed its status
+        self.assertFalse(self.moderation_request2.is_approved())
+        self.assertTrue(self.moderation_request2.is_rejected())
+        self.assertTrue(self.moderation_request2.is_active)
+        moderation_request2_actions = self.moderation_request2.actions.all()
+        self.assertEqual(moderation_request2_actions.count(), 2)
+        self.assertTrue(moderation_request2_actions[0].is_archived)
+        self.assertFalse(moderation_request2_actions[1].is_archived)
+        self.assertTrue(self.moderation_request1.is_approved())
+
+        # Expected users were notified
+        self.assertFalse(notify_moderators_mock.called)
+        notify_author_mock.assert_called_once_with(
+            collection=self.collection,
+            moderation_requests=[self.moderation_request2],
+            action=self.moderation_request2.get_last_action().action,
+            by_user=self.user,
+        )
+
+        # Collection still in review as version2 is still draft
+        self.collection.refresh_from_db()
+        self.assertEqual(self.collection.status, constants.IN_REVIEW)
+
+    def test_reject_selected_view_when_using_get(self):
+        # Choose the reject_selected action from the dropdown
+        data = get_url_data(self, "reject_selected")
+        response = self.client.post(self.url, data)
+        # And follow the redirect (with a GET call) to the view that does the publish
+        response = self.client.get(response.url)
+
+        # Smoke test the response. When using a GET call not a lot happens.
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.templates[0].name,
+            'admin/djangocms_moderation/moderationrequest/rework_confirmation.html'
+        )
+
+    def test_404_on_nonexisting_collection(self):
+        # Need to access the view directly to test for this
+        url = reverse("admin:djangocms_moderation_moderationrequest_rework")
+        url += "?ids=1,2&collection_id=12342"
+
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_404_on_invalid_collection_id(self):
+        # Need to access the view directly to test for this
+        url = reverse("admin:djangocms_moderation_moderationrequest_rework")
+        url += "?ids=1,2&collection_id=aaa"
+
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 404)
+
+    # TODO: This needs to be verified because unlike with other views
+    # no code throws a 403 on non-author but the list of actions does
+    # appear to filter the action dropdown for this user. Hard to say
+    # what is the correct behaviour or if this test makes correct
+    # assumptions in user set up.
+    def test_reject_selected_action_cannot_be_accessed_if_not_collection_author(self):
+        # Login as a user who is not the collection author
+        self.client.force_login(self.role2.user)
+
+        # Choose the reject_selected action from the dropdown
+        data = get_url_data(self, "reject_selected")
+        response = self.client.post(self.url, data)
+
+        # The action is not on the page as available to somebody who is not
+        # the author, therefore django will just return 200 as you're
+        # trying to choose an action that isn't in the dropdown
+        # (if anything had been resubmitted it would have been a 302)
+        self.assertEqual(response.status_code, 200)
+
+    @mock.patch("django.contrib.messages.success")
+    @mock.patch(
+        "djangocms_moderation.models.ModerationRequest.user_can_take_moderation_action",
+        mock.Mock(return_value=False)
+    )
+    @mock.patch("djangocms_moderation.admin.notify_collection_moderators")
+    @mock.patch("djangocms_moderation.admin.notify_collection_author")
+    def test_view_doesnt_reject_when_user_cant_take_moderation_action(
+        self, notify_author_mock, notify_moderators_mock, messages_mock
+    ):
+        # Set up the url (need to access the view directly)
+        url = reverse("admin:djangocms_moderation_moderationrequest_rework")
+        url += "?ids=%d,%d&collection_id=%d" % (
+            self.moderation_request1.pk, self.moderation_request2.pk, self.collection.pk)
+
+        response = self.client.post(url)
+
+        # Check response
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(
+            messages_mock.call_args[0][1],
+            '0 requests successfully submitted for rework'
+        )
+
+        # The request has not changed
+        self.assertFalse(self.moderation_request2.is_approved())
+        self.assertFalse(self.moderation_request2.is_rejected())
+
+        # Collection still in review
+        self.collection.refresh_from_db()
+        self.assertEqual(self.collection.status, constants.IN_REVIEW)
+
+        # Nobody was notified
+        self.assertFalse(notify_moderators_mock.called)
+        self.assertFalse(notify_author_mock.called)
+
+
+class PublishSelectedTest(CMSTestCase):
+
+    def setUp(self):
+        # Set up the db data
+        self.user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.collection = factories.ModerationCollectionFactory(
+            author=self.user, status=constants.IN_REVIEW)
+        self.role1 = Role.objects.create(name="Role 1", user=self.user)
+        self.role2 = Role.objects.create(name="Role 2", user=factories.UserFactory(is_staff=True, is_superuser=True))
+        self.collection.workflow.steps.create(role=self.role1, is_required=True, order=1)
+        self.collection.workflow.steps.create(role=self.role2, is_required=True, order=1)
+        # NOTE: Setting ids because we want the ids of the requests to be
+        # different to the ids of the nodes. This will give us confidence
+        # that the ids of the correct objects are being passed to the
+        # correct places.
+        self.moderation_request1 = factories.ModerationRequestFactory(
+            id=1, collection=self.collection)
+        self.moderation_request2 = factories.ModerationRequestFactory(
+            id=2, collection=self.collection)
+        self.root1 = factories.RootModerationRequestTreeNodeFactory(
+            id=4, moderation_request=self.moderation_request1)
+        factories.ChildModerationRequestTreeNodeFactory(
+            id=5, moderation_request=self.moderation_request2, parent=self.root1)
+        self.root2 = factories.RootModerationRequestTreeNodeFactory(
+            id=6, moderation_request=self.moderation_request2)
+        # Request 1 is approved, request 2 is started
+        self.moderation_request1.actions.create(by_user=self.user, action=constants.ACTION_STARTED)
+        self.moderation_request2.actions.create(by_user=self.user, action=constants.ACTION_STARTED)
+        self.moderation_request1.update_status(constants.ACTION_APPROVED, self.role1.user)
+        self.moderation_request1.update_status(constants.ACTION_APPROVED, self.role2.user)
+
+        # Login as the collection author
+        self.client.force_login(self.user)
+
+        # Set up the url data
+        self.url = reverse("admin:djangocms_moderation_moderationrequesttreenode_changelist")
+        self.url += "?moderation_request__collection__id={}".format(self.collection.pk)
+
+        # Asserts to check data set up is ok. Ideally wouldn't need them, but
+        # the set up is so complex that it's safer to have them.
+        self.assertTrue(self.moderation_request1.is_active)
+        self.assertTrue(self.moderation_request2.is_active)
+        self.assertEqual(self.moderation_request1.version.state, DRAFT)
+        self.assertEqual(self.moderation_request2.version.state, DRAFT)
+
+    @mock.patch("django.contrib.messages.success")
+    def test_publish_selected_publishes_approved_request(self, messages_mock):
+        # Select the publish action from the menu
+
+        data = get_url_data(self, "publish_selected")
+        response = self.client.post(self.url, data)
+        # And now go to the view the action redirects to
+        response = self.client.post(response.url)
+
+        # Response is correct
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(messages_mock.call_args[0][1], '1 request successfully published')
+
+        # Check approved request was published and started request was not
+        # NOTE: We can't do refresh_from_db() for Version, as it complains about
+        # `state` field being changed directly
+        version1 = Version.objects.get(pk=self.moderation_request1.version.pk)
+        version2 = Version.objects.get(pk=self.moderation_request2.version.pk)
+        self.moderation_request1.refresh_from_db()
+        self.moderation_request2.refresh_from_db()
+        self.assertEqual(version1.state, PUBLISHED)
+        self.assertEqual(version2.state, DRAFT)
+        self.assertFalse(self.moderation_request1.is_active)
+        self.assertTrue(self.moderation_request2.is_active)
+
+        # Collection still in review as version2 is still draft
+        self.collection.refresh_from_db()
+        self.assertEqual(self.collection.status, constants.IN_REVIEW)
+
+    @unittest.skip("Skip until collection status bugs fixed")
+    @mock.patch("django.contrib.messages.success")
+    def test_publish_selected_sets_collection_to_archived_if_all_requests_published(self, messages_mock):
+        # Make sure both moderation requests have been approved
+        self.moderation_request2.update_status(constants.ACTION_APPROVED, self.role1.user)
+        self.moderation_request2.update_status(constants.ACTION_APPROVED, self.role2.user)
+
+        # Select the publish action from the menu
+        data = get_url_data(self, "publish_selected")
+        response = self.client.post(self.url, data)
+        # And now go to the view the action redirects to
+        response = self.client.post(response.url)
+
+        # Response is correct
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(messages_mock.call_args[0][1], '2 requests successfully published')
+
+        # Check both approved request were published
+        # NOTE: We can't do refresh_from_db() for Version, as it complains about
+        # `state` field being changed directly
+        version1 = Version.objects.get(pk=self.moderation_request1.version.pk)
+        version2 = Version.objects.get(pk=self.moderation_request2.version.pk)
+        self.moderation_request1.refresh_from_db()
+        self.moderation_request2.refresh_from_db()
+        self.assertEqual(version1.state, PUBLISHED)
+        self.assertEqual(version2.state, PUBLISHED)
+        self.assertFalse(self.moderation_request1.is_active)
+        self.assertFalse(self.moderation_request2.is_active)
+
+        # Collection should be archived as both requests are now published
+        self.collection.refresh_from_db()
+        self.assertEqual(self.collection.status, constants.ARCHIVED)
+
+    def test_publish_selected_view_when_using_get(self):
+        # Choose the publish_selected action from the dropdown
+        data = get_url_data(self, "publish_selected")
+        response = self.client.post(self.url, data)
+        # And follow the redirect (with a GET call) to the view that does the publish
+        response = self.client.get(response.url)
+
+        # Smoke test the response. When using a GET call not a lot happens.
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.templates[0].name,
+            'admin/djangocms_moderation/moderationrequest/publish_confirmation.html'
+        )
+
+    def test_404_on_nonexisting_collection(self):
+        # Need to access the view directly to test for this
+        url = reverse("admin:djangocms_moderation_moderationrequest_publish")
+        url += "?ids=1,2&collection_id=12342"
+
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_404_on_invalid_collection_id(self):
+        # Need to access the view directly to test for this
+        url = reverse("admin:djangocms_moderation_moderationrequest_publish")
+        url += "?ids=1,2&collection_id=aaa"
+
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_publish_selected_action_cannot_be_accessed_if_not_collection_author(self):
+        # Login as a user who is not the collection author
+        self.client.force_login(self.get_superuser())
+
+        # Choose the resubmit_selected action from the dropdown
+        data = get_url_data(self, "publish_selected")
+        response = self.client.post(self.url, data)
+
+        # The action is not on the page as available to somebody who is not
+        # the author, therefore django will just return 200 as you're
+        # trying to choose an action that isn't in the dropdown
+        # (if anything had been resubmitted it would have been a 302)
+        self.assertEqual(response.status_code, 200)
+
+    def test_publish_selected_view_cannot_be_accessed_if_not_collection_author(self):
+        # Login as a user who is not the collection author
+        self.client.force_login(self.get_superuser())
+        # Set up the url (need to access the view directly)
+        url = reverse("admin:djangocms_moderation_moderationrequest_publish")
+        url += "?ids=%d,%d&collection_id=%d" % (
+            self.moderation_request1.pk, self.moderation_request2.pk, self.collection.pk)
+
+        # POST directly to the view, don't go through actions
+        response = self.client.post(url)
+
+        # Check response
+        self.assertEqual(response.status_code, 403)
+
+        # Nothing is published
+        version1 = Version.objects.get(pk=self.moderation_request1.version.pk)
+        version2 = Version.objects.get(pk=self.moderation_request2.version.pk)
+        self.moderation_request1.refresh_from_db()
+        self.moderation_request2.refresh_from_db()
+        self.assertEqual(version1.state, DRAFT)
+        self.assertEqual(version2.state, DRAFT)
+        self.assertTrue(self.moderation_request1.is_active)
+        self.assertTrue(self.moderation_request2.is_active)
+
+        # Collection still in review
+        self.collection.refresh_from_db()
+        self.assertEqual(self.collection.status, constants.IN_REVIEW)
+
+    @mock.patch("django.contrib.messages.success")
+    @mock.patch("djangocms_moderation.models.ModerationRequest.version_can_be_published", mock.Mock(return_value=False))
+    def test_view_doesnt_publish_when_version_cant_be_published(self, messages_mock):
+        # Set up the url (need to access the view directly)
+        url = reverse("admin:djangocms_moderation_moderationrequest_publish")
+        url += "?ids=%d,%d&collection_id=%d" % (
+            self.moderation_request1.pk, self.moderation_request2.pk, self.collection.pk)
+
+        response = self.client.post(url)
+
+        # Check response
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(messages_mock.call_args[0][1], '0 requests successfully published')
+
+        # Nothing is published
+        version1 = Version.objects.get(pk=self.moderation_request1.version.pk)
+        version2 = Version.objects.get(pk=self.moderation_request2.version.pk)
+        self.moderation_request1.refresh_from_db()
+        self.moderation_request2.refresh_from_db()
+        self.assertEqual(version1.state, DRAFT)
+        self.assertEqual(version2.state, DRAFT)
+        self.assertTrue(self.moderation_request1.is_active)
+        self.assertTrue(self.moderation_request2.is_active)
+
+        # Collection still in review
+        self.collection.refresh_from_db()
+        self.assertEqual(self.collection.status, constants.IN_REVIEW)
+
+
+class ResubmitSelectedTest(CMSTestCase):
+
+    def setUp(self):
+        # Set up the db data
+        self.user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.collection = factories.ModerationCollectionFactory(
+            author=self.user, status=constants.IN_REVIEW)
+        # NOTE: Setting ids because we want the ids of the requests to be
+        # different to the ids of the nodes. This will give us confidence
+        # that the ids of the correct objects are being passed to the
+        # correct places.
+        self.moderation_request1 = factories.ModerationRequestFactory(
+            id=1, collection=self.collection)
+        self.moderation_request2 = factories.ModerationRequestFactory(
+            id=2, collection=self.collection)
+        # Make self.moderation_request2 rejected
+        self.moderation_request2.update_status(action=ACTION_REJECTED, by_user=self.user)
+        self.root1 = factories.RootModerationRequestTreeNodeFactory(
+            id=4, moderation_request=self.moderation_request1)
+        factories.ChildModerationRequestTreeNodeFactory(
+            id=5, moderation_request=self.moderation_request2, parent=self.root1)
+        self.root2 = factories.RootModerationRequestTreeNodeFactory(
+            id=6, moderation_request=self.moderation_request2)
+
+        # Login as the collection author
+        self.client.force_login(self.user)
+
+        self.url = reverse("admin:djangocms_moderation_moderationrequesttreenode_changelist")
+        self.url += "?moderation_request__collection__id={}".format(self.collection.pk)
+
+        # Asserts to check data set up is ok. Ideally wouldn't need them, but
+        # the set up is so complex that it's safer to have them.
+        self.assertTrue(self.moderation_request2.is_rejected())
+        self.assertTrue(self.moderation_request1.is_approved())
+        self.assertEqual(self.collection.status, constants.IN_REVIEW)
+
+    @mock.patch("djangocms_moderation.admin.notify_collection_moderators")
+    @mock.patch("djangocms_moderation.admin.notify_collection_author")
+    @mock.patch("django.contrib.messages.success")
+    def test_resubmit_selected_resubmits_rejected_request(
+        self, messages_mock, notify_author_mock, notify_moderators_mock
+    ):
+        # Choose the resubmit_selected action from the dropdown
+        data = get_url_data(self, "resubmit_selected")
+        response = self.client.post(self.url, data)
+        # And follow the redirect to the view that does the resubmit
+        response = self.client.post(response.url)
+
+        # Response is correct
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(messages_mock.call_args[0][1], '1 request successfully resubmitted for review')
+
+        # Rejected request was resubmitted and approved request did not change
+        self.assertFalse(self.moderation_request2.is_rejected())
+        self.assertTrue(self.moderation_request2.actions.filter(
+            action=constants.ACTION_RESUBMITTED, by_user=self.user).exists())
+        self.assertTrue(self.moderation_request1.is_approved())
+
+        # Collection status has not changed
+        self.collection.refresh_from_db()
+        self.assertEqual(self.collection.status, constants.IN_REVIEW)
+
+        # Expected users were notified
+        self.assertFalse(notify_author_mock.called)
+        notify_moderators_mock.assert_called_once_with(
+            collection=self.collection,
+            moderation_requests=[self.moderation_request2],
+            action_obj=self.moderation_request2.get_last_action(),
+        )
+
+    def test_resubmit_selected_view_when_using_get(self):
+        # Choose the resubmit_selected action from the dropdown
+        data = get_url_data(self, "resubmit_selected")
+        response = self.client.post(self.url, data)
+        # And follow the redirect (with a GET call) to the view that does the resubmit
+        response = self.client.get(response.url)
+
+        # Smoke test the response. When using a GET call not a lot happens.
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.templates[0].name,
+            'admin/djangocms_moderation/moderationrequest/resubmit_confirmation.html'
+        )
+
+    def test_404_on_nonexisting_collection(self):
+        # Need to access the view directly to test for this
+        url = reverse("admin:djangocms_moderation_moderationrequest_resubmit")
+        url += "?ids=1,2&collection_id=12342"
+
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_404_on_invalid_collection_id(self):
+        # Need to access the view directly to test for this
+        url = reverse("admin:djangocms_moderation_moderationrequest_resubmit")
+        url += "?ids=1,2&collection_id=aaa"
+
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 404)
+
+    @mock.patch("djangocms_moderation.admin.notify_collection_moderators")
+    @mock.patch("django.contrib.messages.success")
+    @mock.patch("djangocms_moderation.models.ModerationRequest.user_can_resubmit", mock.Mock(return_value=False))
+    def test_view_doesnt_resubmit_when_user_cant_resubmit(self, messages_mock, notify_moderators_mock):
+        # Set up the url (need to access the view directly)
+        url = reverse("admin:djangocms_moderation_moderationrequest_resubmit")
+        url += "?ids=%d,%d&collection_id=%d" % (
+            self.moderation_request1.pk, self.moderation_request2.pk, self.collection.pk)
+
+        response = self.client.post(url)
+
+        # Check response
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, self.url)
+        self.assertEqual(messages_mock.call_args[0][1], '0 requests successfully resubmitted for review')
+        # No actions were resubmitted
+        self.assertFalse(self.moderation_request2.actions.filter(
+            action=constants.ACTION_RESUBMITTED).exists())
+        self.assertEqual(notify_moderators_mock.call_count, 0)
+
+    def test_resubmit_selected_action_cannot_be_accessed_if_not_collection_author(self):
+        # Login as a user who is not the collection author
+        self.client.force_login(self.get_superuser())
+
+        # Choose the resubmit_selected action from the dropdown
+        data = get_url_data(self, "resubmit_selected")
+        response = self.client.post(self.url, data)
+
+        # The action is not on the page as available to somebody who is not
+        # the author, therefore django will just return 200 as you're
+        # trying to choose an action that isn't in the dropdown
+        # (if anything had been resubmitted it would have been a 302)
+        self.assertEqual(response.status_code, 200)
+
+    @mock.patch("djangocms_moderation.admin.notify_collection_moderators")
+    def test_resubmit_selected_view_cannot_be_accessed_if_not_collection_author(self, notify_moderators_mock):
+        # Login as a user who is not the collection author
+        self.client.force_login(self.get_superuser())
+        # Set up the url (need to access the view directly)
+        url = reverse("admin:djangocms_moderation_moderationrequest_resubmit")
+        url += "?ids=%d,%d&collection_id=%d" % (
+            self.moderation_request1.pk, self.moderation_request2.pk, self.collection.pk)
+
+        # POST directly to the view, don't go through actions
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 403)
+        # Nothing is resubmitted
+        self.assertFalse(self.moderation_request2.actions.filter(
+            action=constants.ACTION_RESUBMITTED).exists())
+        # Notifications not sent
+        self.assertFalse(notify_moderators_mock.called)
 
 
 class DeleteSelectedTest(CMSTestCase):
@@ -305,31 +924,32 @@ class DeleteSelectedTest(CMSTestCase):
         self.user = factories.UserFactory(is_staff=True, is_superuser=True)
         self.collection = factories.ModerationCollectionFactory(
             author=self.user, status=constants.IN_REVIEW)
+        # NOTE: Setting ids because we want the ids of the requests to be
+        # different to the ids of the nodes. This will give us confidence
+        # that the ids of the correct objects are being passed to the
+        # correct places.
         self.moderation_request1 = factories.ModerationRequestFactory(
-            collection=self.collection)
+            id=1, collection=self.collection)
         self.moderation_request2 = factories.ModerationRequestFactory(
-            collection=self.collection)
+            id=2, collection=self.collection)
         self.root1 = factories.RootModerationRequestTreeNodeFactory(
-            moderation_request=self.moderation_request1)
-        self.root2 = factories.RootModerationRequestTreeNodeFactory(
-            moderation_request=self.moderation_request2)
+            id=4, moderation_request=self.moderation_request1)
         factories.ChildModerationRequestTreeNodeFactory(
-            moderation_request=self.moderation_request1, parent=self.root1)
+            id=5, moderation_request=self.moderation_request2, parent=self.root1)
+        self.root2 = factories.RootModerationRequestTreeNodeFactory(
+            id=6, moderation_request=self.moderation_request2)
+
+        self.url = reverse("admin:djangocms_moderation_moderationrequesttreenode_changelist")
+        self.url += "?moderation_request__collection__id={}".format(self.collection.pk)
 
     @mock.patch.object(ModerationRequestTreeAdmin, "has_delete_permission", mock.Mock(return_value=True))
     def test_delete_selected_action_cannot_be_accessed_if_not_collection_author(self):
         # Login as a user who is not the collection author
         self.client.force_login(self.get_superuser())
-        # Set up action url
-        url = reverse("admin:djangocms_moderation_moderationrequesttreenode_changelist")
-        url += "?moderation_request__collection__id={}".format(self.collection.pk)
 
         # Choose the delete_selected action from the dropdown
-        data = {
-            "action": "delete_selected",
-            ACTION_CHECKBOX_NAME: [str(self.moderation_request1.pk), str(self.moderation_request2.pk)]
-        }
-        response = self.client.post(url, data)
+        data = get_url_data(self, "delete_selected")
+        response = self.client.post(self.url, data)
 
         # The action is not on the page as available to somebody who is not
         # the author, therefore django will just return 200 as you're
@@ -366,14 +986,8 @@ class DeleteSelectedTest(CMSTestCase):
         # Login as the collection author
         self.client.force_login(self.user)
         # Choose the delete_selected action from the dropdown
-        url = reverse("admin:djangocms_moderation_moderationrequesttreenode_changelist")
-        url += "?moderation_request__collection__id={}".format(self.collection.pk)
-        data = {
-            "action": "delete_selected",
-            ACTION_CHECKBOX_NAME: [str(self.moderation_request1.pk), str(self.moderation_request2.pk)]
-        }
-
-        response = self.client.post(url, data)
+        data = get_url_data(self, "delete_selected")
+        response = self.client.post(self.url, data)
 
         self.assertEqual(response.status_code, 403)
 
@@ -401,28 +1015,25 @@ class DeleteSelectedTest(CMSTestCase):
         # Notifications not sent
         self.assertFalse(notify_author_mock.called)
 
+    @mock.patch("django.contrib.messages.success")
     @mock.patch.object(ModerationRequestTreeAdmin, "has_delete_permission", mock.Mock(return_value=True))
     @mock.patch("djangocms_moderation.admin.notify_collection_moderators")
     @mock.patch("djangocms_moderation.admin.notify_collection_author")
-    def test_delete_selected_deletes_all_relevant_objects(self, notify_author_mock, notify_moderators_mock):
+    def test_delete_selected_deletes_all_relevant_objects(
+        self, notify_author_mock, notify_moderators_mock, messages_mock
+    ):
         """The selected ModerationRequest and ModerationRequestTreeNode objects should be deleted."""
         # Login as the collection author
         self.client.force_login(self.user)
         # Choose the delete_selected action from the dropdown
-        url = reverse("admin:djangocms_moderation_moderationrequesttreenode_changelist")
-        url += "?moderation_request__collection__id={}".format(self.collection.pk)
-
-        get_resp = self.client.get(url)
-        data = {
-            "action": "delete_selected",
-            ACTION_CHECKBOX_NAME: [str(f.pk) for f in get_resp.context['cl'].queryset]
-        }
-        response = self.client.post(url, data)
+        data = get_url_data(self, "delete_selected")
+        response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, 302)
 
         # Now do the request the delete_selected action has led us to
         response = self.client.post(response.url)
-        self.assertRedirects(response, url)
+        self.assertRedirects(response, self.url)
+        self.assertEqual(messages_mock.call_args[0][1], '2 requests successfully deleted')
         # And check the requests have indeed been deleted
         self.assertEqual(ModerationRequest.objects.filter(collection=self.collection).count(), 0)
         # And correct notifications sent out
@@ -436,6 +1047,24 @@ class DeleteSelectedTest(CMSTestCase):
         # All moderation requests were deleted, so collection should be archived
         self.collection.refresh_from_db()
         self.assertEqual(self.collection.status, constants.ARCHIVED)
+
+    def test_delete_view_when_using_get(self):
+        # Login as the collection author
+        self.client.force_login(self.user)
+        # Choose the delete_selected action from the dropdown
+
+        # Choose the approve_selected action from the dropdown
+        data = get_url_data(self, "delete_selected")
+        response = self.client.post(self.url, data)
+        # And follow the redirect (with a GET call) to the view that does the approve
+        response = self.client.get(response.url)
+
+        # Smoke test the response. When using a GET call not a lot happens.
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.templates[0].name,
+            'admin/djangocms_moderation/moderationrequest/delete_confirmation.html'
+        )
 
 
 class DeletedSelectedTransactionTest(TransactionTestCase):
@@ -462,10 +1091,7 @@ class DeletedSelectedTransactionTest(TransactionTestCase):
         # Generate url and POST data
         self.url = reverse("admin:djangocms_moderation_moderationrequesttreenode_changelist")
         self.url += "?moderation_request__collection__id={}".format(self.collection.pk)
-        self.data = {
-            "action": "delete_selected",
-            ACTION_CHECKBOX_NAME: [str(self.moderation_request1.pk), str(self.moderation_request2.pk)]
-        }
+        self.data = get_url_data(self, "delete_selected")
 
     def tearDown(self):
         """Clear content type cache for page content's versionable.

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -42,6 +42,9 @@ class SignalsTestCase(CMSTestCase):
         moderation_request = factories.ModerationRequestFactory(
             collection__status=constants.COLLECTING, author=user
         )
+        moderation_request.collection.author = user
+        moderation_request.collection.save()
+
         self.root = factories.RootModerationRequestTreeNodeFactory(
             moderation_request=moderation_request
         )
@@ -53,16 +56,16 @@ class SignalsTestCase(CMSTestCase):
         )
 
         with signal_tester(submitted_for_review) as env:
-            with self.login_user_context(user):
-                self.client.post(
-                    add_url_parameters(
-                        reverse(
-                            "admin:djangocms_moderation_moderationrequest_resubmit"
-                        ),
-                        collection_id=moderation_request.collection_id,
-                        ids=self.root.pk,
-                    )
+            self.client.force_login(user)
+            self.client.post(
+                add_url_parameters(
+                    reverse(
+                        "admin:djangocms_moderation_moderationrequest_resubmit"
+                    ),
+                    collection_id=moderation_request.collection_id,
+                    ids=self.root.pk,
                 )
+            )
 
             self.assertEqual(env.call_count, 1)
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -42,6 +42,9 @@ class SignalsTestCase(CMSTestCase):
         moderation_request = factories.ModerationRequestFactory(
             collection__status=constants.COLLECTING, author=user
         )
+        self.root = factories.RootModerationRequestTreeNodeFactory(
+            moderation_request=moderation_request
+        )
         moderation_request.collection.workflow.steps.create(
             role=Role.objects.create(name="Role 1", user=reviewer), order=1
         )
@@ -57,7 +60,7 @@ class SignalsTestCase(CMSTestCase):
                             "admin:djangocms_moderation_moderationrequest_resubmit"
                         ),
                         collection_id=moderation_request.collection_id,
-                        ids=moderation_request.pk,
+                        ids=self.root.pk,
                     )
                 )
 


### PR DESCRIPTION
Prior to this PR the admin actions assumed it would accept ids for `ModerationRequest`. As of this PR: #144 this assumption changed. The admin action should accept ids for a `ModerationRequestTreeNode`. 

This PR changes the tests to check the changelist view and picks the selected ids from there, it then posts those ids for the selected action. 