### PR TITLE
Support django 2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: false
-      - run: docker build -f .circleci/Dockerfile --build-arg PYTHON_VERSION=3.6 -t py37 .
+      - run: docker build -f .circleci/Dockerfile --build-arg PYTHON_VERSION=3.7 -t py37 .
       - run: mkdir images
       - run: docker save -o images/py37.tar py37
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,6 @@ py36default: &py36default
    - run: docker load -i /tmp/images/py36.tar || true
    - run: docker run py36 tox -e $CIRCLE_STAGE
 
-py34_requires: &py34_requires
-  requires:
-    - py34_base
-
 py35_requires: &py35_requires
   requires:
     - py35_base
@@ -50,19 +46,6 @@ py36_requires: &py36_requires
     - py36_base
 
 jobs:
-  py34_base:
-    docker:
-      - image: circleci/python:3.4
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: false
-      - run: docker build -f .circleci/Dockerfile --build-arg PYTHON_VERSION=3.4 -t py34 .
-      - run: mkdir images
-      - run: docker save -o images/py34.tar py34
-      - persist_to_workspace:
-         root: images
-         paths: py34.tar
   py36_base:
     docker:
       - image: circleci/python:3.6
@@ -106,8 +89,6 @@ jobs:
          at: /tmp/images
      - run: docker load -i /tmp/images/py35.tar || true
      - run: docker run py35 gulp lint
-  py34-dj111-sqlite-cms4:
-    <<: *py34default
   py35-dj111-sqlite-cms4:
     <<: *py35default
   py36-dj111-sqlite-cms4:
@@ -125,7 +106,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - py34_base
       - py35_base
       - py36_base
       - flake8:
@@ -137,9 +117,6 @@ workflows:
       - eslint:
           requires:
             - py35_base
-      - py34-dj111-sqlite-cms4:
-          requires:
-            - py34_base
       - py35-dj111-sqlite-cms4:
           requires:
             - py35_base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,5 @@
 version: 2.0
 
-py34default: &py34default
-  docker:
-    - image: circleci/python:3.4
-  steps:
-   - setup_remote_docker:
-       docker_layer_caching: false
-   - checkout
-   - attach_workspace:
-       at: /tmp/images
-   - run: docker load -i /tmp/images/py34.tar || true
-   - run: docker run py34 tox -e $CIRCLE_STAGE
-
 py35default: &py35default
   docker:
     - image: circleci/python:3.5
@@ -93,11 +81,15 @@ jobs:
     <<: *py35default
   py36-dj111-sqlite-cms4:
     <<: *py36default
-  py34-dj20-sqlite-cms4:
-    <<: *py34default
+
   py35-dj20-sqlite-cms4:
     <<: *py35default
   py36-dj20-sqlite-cms4:
+    <<: *py36default
+
+  py35-dj22-sqlite-cms4:
+    <<: *py35default
+  py36-dj22-sqlite-cms4:
     <<: *py36default
 
 #######################
@@ -123,12 +115,18 @@ workflows:
       - py36-dj111-sqlite-cms4:
           requires:
             - py36_base
-      - py34-dj20-sqlite-cms4:
-          requires:
-            - py34_base
+
       - py35-dj20-sqlite-cms4:
           requires:
             - py35_base
       - py36-dj20-sqlite-cms4:
+          requires:
+            - py36_base
+
+
+      - py35-dj22-sqlite-cms4:
+          requires:
+            - py35_base
+      - py36-dj22-sqlite-cms4:
           requires:
             - py36_base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,19 @@ py36default: &py36default
    - run: docker load -i /tmp/images/py36.tar || true
    - run: docker run py36 tox -e $CIRCLE_STAGE
 
+py37default: &py37default
+  docker:
+    - image: circleci/python:3.7
+  steps:
+   - setup_remote_docker:
+       docker_layer_caching: false
+   - checkout
+   - attach_workspace:
+       at: /tmp/images
+   - run: docker load -i /tmp/images/py37.tar || true
+   - run: docker run py37 tox -e $CIRCLE_STAGE
+
+
 py35_requires: &py35_requires
   requires:
     - py35_base
@@ -33,7 +46,25 @@ py36_requires: &py36_requires
   requires:
     - py36_base
 
+py37_requires: &py37_requires
+  requires:
+    - py37_base
+
 jobs:
+  py37_base:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - run: docker build -f .circleci/Dockerfile --build-arg PYTHON_VERSION=3.6 -t py37 .
+      - run: mkdir images
+      - run: docker save -o images/py37.tar py37
+      - persist_to_workspace:
+         root: images
+         paths: py37.tar
+
   py36_base:
     docker:
       - image: circleci/python:3.6
@@ -81,16 +112,23 @@ jobs:
     <<: *py35default
   py36-dj111-sqlite-cms4:
     <<: *py36default
+  py37-dj111-sqlite-cms4:
+    <<: *py37default
 
   py35-dj20-sqlite-cms4:
     <<: *py35default
   py36-dj20-sqlite-cms4:
     <<: *py36default
+  py37-dj20-sqlite-cms4:
+    <<: *py37default
 
   py35-dj22-sqlite-cms4:
     <<: *py35default
   py36-dj22-sqlite-cms4:
     <<: *py36default
+  py37-dj22-sqlite-cms4:
+    <<: *py37default
+
 
 #######################
 
@@ -100,6 +138,7 @@ workflows:
     jobs:
       - py35_base
       - py36_base
+      - py37_base
       - flake8:
           requires:
             - py35_base
@@ -115,6 +154,9 @@ workflows:
       - py36-dj111-sqlite-cms4:
           requires:
             - py36_base
+      - py37-dj111-sqlite-cms4:
+          requires:
+            - py37_base
 
       - py35-dj20-sqlite-cms4:
           requires:
@@ -122,7 +164,9 @@ workflows:
       - py36-dj20-sqlite-cms4:
           requires:
             - py36_base
-
+      - py37-dj20-sqlite-cms4:
+          requires:
+            - py37_base
 
       - py35-dj22-sqlite-cms4:
           requires:
@@ -130,3 +174,6 @@ workflows:
       - py36-dj22-sqlite-cms4:
           requires:
             - py36_base
+      - py37-dj22-sqlite-cms4:
+          requires:
+            - py37_base

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ to perform the application's database migrations.
 Documentation
 =============
 
-We maintain documentation under ``docs`` folder using rst format. HTML documentation can be generated using the following command
+We maintain documentation under ``docs`` folder using rst format. HTML documentation can be generated using the following commands
 
 Run::
 

--- a/djangocms_moderation/admin.py
+++ b/djangocms_moderation/admin.py
@@ -318,7 +318,7 @@ class ModerationRequestTreeAdmin(TreeAdmin):
 
         # Only collection author can delete moderation requests
         if collection.author == request.user:
-            actions_to_keep.append("delete_selected")
+            actions_to_keep.append("remove_selected")
 
         return {key: value for key, value in actions.items() if key in actions_to_keep}
 

--- a/djangocms_moderation/admin_actions.py
+++ b/djangocms_moderation/admin_actions.py
@@ -63,6 +63,9 @@ def approve_selected(modeladmin, request, queryset):
     return HttpResponseRedirect(url)
 
 
+approve_selected.short_description = _("Approve")
+
+
 def delete_selected(modeladmin, request, queryset):
     if not modeladmin.has_delete_permission(request):
         raise PermissionDenied
@@ -77,6 +80,7 @@ def delete_selected(modeladmin, request, queryset):
 
 
 delete_selected.short_description = _("Remove selected")
+delete_selected.__name__ = 'remove_selected'
 
 
 def publish_selected(modeladmin, request, queryset):

--- a/djangocms_moderation/contrib/moderation_forms/cms_plugins.py
+++ b/djangocms_moderation/contrib/moderation_forms/cms_plugins.py
@@ -3,6 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 from cms.plugin_pool import plugin_pool
 
 from aldryn_forms.cms_plugins import FormPlugin
+
 from djangocms_moderation.helpers import get_page_or_404
 from djangocms_moderation.signals import confirmation_form_submission
 

--- a/djangocms_moderation/forms.py
+++ b/djangocms_moderation/forms.py
@@ -136,10 +136,13 @@ class CollectionItemsForm(forms.Form):
     def set_collection_widget(self, request):
         related_modeladmin = admin.site._registry.get(ModerationCollection)
         dbfield = ModerationRequest._meta.get_field("collection")
+
+        remote_field = dbfield.rel if hasattr(dbfield, 'rel') else dbfield.remote_field
+
         formfield = self.fields["collection"]
         formfield.widget = RelatedFieldWidgetWrapper(
             formfield.widget,
-            dbfield.rel,
+            remote_field,
             admin_site=admin.site,
             can_add_related=related_modeladmin.has_add_permission(request),
             can_change_related=related_modeladmin.has_change_permission(request),

--- a/djangocms_moderation/forms.py
+++ b/djangocms_moderation/forms.py
@@ -137,6 +137,7 @@ class CollectionItemsForm(forms.Form):
         related_modeladmin = admin.site._registry.get(ModerationCollection)
         dbfield = ModerationRequest._meta.get_field("collection")
 
+        # Django 2.2 requires `remote_field` instead of `rel`.
         remote_field = dbfield.rel if hasattr(dbfield, 'rel') else dbfield.remote_field
 
         formfield = self.fields["collection"]

--- a/djangocms_moderation/models.py
+++ b/djangocms_moderation/models.py
@@ -79,9 +79,11 @@ class Role(models.Model):
         unique=True,
     )
     user = models.ForeignKey(
-        to=settings.AUTH_USER_MODEL, verbose_name=_("user"), blank=True, null=True
+        to=settings.AUTH_USER_MODEL, verbose_name=_("user"), blank=True, null=True, on_delete=models.CASCADE
     )
-    group = models.ForeignKey(to=Group, verbose_name=_("group"), blank=True, null=True)
+    group = models.ForeignKey(
+        to=Group, verbose_name=_("group"), blank=True, null=True, on_delete=models.CASCADE
+    )
     confirmation_page = models.ForeignKey(
         to=ConfirmationPage,
         verbose_name=_("confirmation page"),
@@ -172,10 +174,15 @@ class Workflow(models.Model):
 
 @python_2_unicode_compatible
 class WorkflowStep(models.Model):
-    role = models.ForeignKey(to=Role, verbose_name=_("role"))
+    role = models.ForeignKey(
+        to=Role, verbose_name=_("role"), on_delete=models.CASCADE
+    )
     is_required = models.BooleanField(verbose_name=_("is mandatory"), default=True)
     workflow = models.ForeignKey(
-        to=Workflow, verbose_name=_("workflow"), related_name="steps"
+        to=Workflow,
+        verbose_name=_("workflow"),
+        related_name="steps",
+        on_delete=models.CASCADE
     )
     order = models.PositiveIntegerField()
 
@@ -214,7 +221,8 @@ class ModerationCollection(models.Model):
         on_delete=models.CASCADE,
     )
     workflow = models.ForeignKey(
-        to=Workflow, verbose_name=_("workflow"), related_name="moderation_collections"
+        to=Workflow, verbose_name=_("workflow"), related_name="moderation_collections",
+        on_delete=models.CASCADE
     )
     status = models.CharField(
         max_length=10,
@@ -635,6 +643,7 @@ class ModerationRequestAction(models.Model):
         to=ModerationRequest,
         verbose_name=_("moderation_request"),
         related_name="actions",
+        on_delete=models.CASCADE
     )
 
     date_taken = models.DateTimeField(verbose_name=_("date taken"), auto_now_add=True)

--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,9 @@ setup(
     tests_require=TEST_REQUIREMENTS,
     test_suite="tests.settings.run",
     dependency_links=[
-        "http://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0",
-        "http://github.com/divio/djangocms-versioning/tarball/master#egg=djangocms-versioning-0.0.23",
-        "http://github.com/FidelityInternational/djangocms-version-locking/tarball/master#egg=djangocms-version-locking-0.0.13", # noqa
+        "https://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0",
+        "https://github.com/divio/djangocms-versioning/tarball/master#egg=djangocms-versioning-0.0.23",
+        "https://github.com/FidelityInternational/djangocms-version-locking/tarball/master#egg=djangocms-version-locking-0.0.13", # noqa
         "https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor-4.0.x"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,13 @@ import djangocms_moderation
 
 INSTALL_REQUIREMENTS = [
     "Django>=1.11,<3.0",
-    "django-cms>=3.4.2",
+    "django-cms",
     "django-sekizai>=0.7",
     "django-admin-sortable2>=0.6.4",
 ]
 
 TEST_REQUIREMENTS = [
-    "aldryn-forms",
-    "django-cms",
-    "pillow<=5.4.1",  # Requirement for tests to pass in python 3.4
-    "lxml<=4.3.5",  # Requirement for tests to pass in python 3.4
+    "django_polymorphic==2.0.3",
     "cachetools",
     "mock",
     "djangocms-text-ckeditor",
@@ -48,7 +45,6 @@ setup(
     tests_require=TEST_REQUIREMENTS,
     test_suite="tests.settings.run",
     dependency_links=[
-        "https://github.com/divio/aldryn-forms/tarball/master#egg=aldryn-forms-5.0.1",
         "https://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0",
         "https://github.com/divio/djangocms-versioning/tarball/master#egg=djangocms-versioning-0.0.23",
         "https://github.com/FidelityInternational/djangocms-version-locking/tarball/master#egg=djangocms-version-locking-0.0.13", # noqa

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@ INSTALL_REQUIREMENTS = [
 ]
 
 TEST_REQUIREMENTS = [
-    # Version 5 forces you to use django 2.0 or higher.
-    "aldryn-forms==4.0.1",
+    "aldryn-forms",
     "django-cms",
     "pillow<=5.4.1",  # Requirement for tests to pass in python 3.4
     "lxml<=4.3.5",  # Requirement for tests to pass in python 3.4
@@ -49,9 +48,10 @@ setup(
     tests_require=TEST_REQUIREMENTS,
     test_suite="tests.settings.run",
     dependency_links=[
+        "https://github.com/divio/aldryn-forms/tarball/master#egg=aldryn-forms-5.0.1",
         "https://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0",
         "https://github.com/divio/djangocms-versioning/tarball/master#egg=djangocms-versioning-0.0.23",
-        "https://github.com/FidelityInternational/djangocms-version-locking/tarball/master#egg=djangocms-version-locking-0.0.13", # noqa
+        "https://github.com/jonathan-s/djangocms-version-locking/tarball/setup-django22#egg=djangocms-version-locking-0.0.13", # noqa
         "https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor-4.0.x"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -4,23 +4,27 @@ import djangocms_moderation
 
 
 INSTALL_REQUIREMENTS = [
-    "Django>=1.8,<2.0",
+    "Django>=1.8,<=2.0",
     "django-cms>=3.4.2",
     "django-sekizai>=0.7",
     "django-admin-sortable2>=0.6.4",
 ]
 
 TEST_REQUIREMENTS = [
-    "aldryn-forms",
+    # Version 5 forces you to use django 2.0 or higher.
+    "aldryn-forms==4.0.1",
     "django-cms",
     "pillow<=5.4.1",  # Requirement for tests to pass in python 3.4
     "lxml<=4.3.5",  # Requirement for tests to pass in python 3.4
+    "cachetools",
+    "mock",
     "djangocms-text-ckeditor",
     "djangocms-version-locking",
     "djangocms-versioning",
     "djangocms_helper",
     "factory-boy",
-    "mock"
+    "django-simple-captcha",
+    "python-dateutil>=2.4"
 ]
 
 setup(
@@ -48,7 +52,6 @@ setup(
         "http://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0",
         "http://github.com/divio/djangocms-versioning/tarball/master#egg=djangocms-versioning-0.0.23",
         "http://github.com/FidelityInternational/djangocms-version-locking/tarball/master#egg=djangocms-version-locking-0.0.13", # noqa
-        "https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor-4.0.x",
-        "https://github.com/divio/aldryn-forms/tarball/master#egg=aldryn-forms"
+        "https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor-4.0.x"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "https://github.com/divio/aldryn-forms/tarball/master#egg=aldryn-forms-5.0.1",
         "https://github.com/divio/django-cms/tarball/release/4.0.x#egg=django-cms-4.0.0",
         "https://github.com/divio/djangocms-versioning/tarball/master#egg=djangocms-versioning-0.0.23",
-        "https://github.com/jonathan-s/djangocms-version-locking/tarball/setup-django22#egg=djangocms-version-locking-0.0.13", # noqa
+        "https://github.com/FidelityInternational/djangocms-version-locking/tarball/master#egg=djangocms-version-locking-0.0.13", # noqa
         "https://github.com/divio/djangocms-text-ckeditor/tarball/support/4.0.x#egg=djangocms-text-ckeditor-4.0.x"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import djangocms_moderation
 
 
 INSTALL_REQUIREMENTS = [
-    "Django>=1.8,<=2.0",
+    "Django>=1.11,<3.0",
     "django-cms>=3.4.2",
     "django-sekizai>=0.7",
     "django-admin-sortable2>=0.6.4",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,4 +6,5 @@ isort
 python-dateutil
 mock
 cachetools
-django_polymorphic==2.0.3
+# Please note that aldryn-forms version 5 can only be used with django >2 and deprecates <2 completely. Version 5 is only available on master, not yet on pypi. 
+https://github.com/divio/aldryn-forms/archive/master.zip

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,7 @@ coverage
 pyflakes>=2.1.1
 flake8
 isort
+python-dateutil
+mock
+cachetools
+django_polymorphic==2.0.3

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -83,12 +83,14 @@ class ModerationAdminTestCase(BaseTestCase):
         mock_request._collection = self.collection
         actions = self.mr_tree_admin.get_actions(request=mock_request)
         self.assertIn("remove_selected", actions)
+        self.assertNotIn("delete_selected", actions)
 
         # user2 won't be able to delete requests, as they are not the collection
         # author
         mock_request.user = self.user2
         actions = self.mr_tree_admin.get_actions(request=mock_request)
         self.assertNotIn("delete_selected", actions)
+        self.assertNotIn("remove_selected", actions)
 
     def test_publish_selected_action_visibility_when_version_is_published(self):
         mock_request = MockRequest()

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -82,7 +82,7 @@ class ModerationAdminTestCase(BaseTestCase):
         mock_request.user = self.user
         mock_request._collection = self.collection
         actions = self.mr_tree_admin.get_actions(request=mock_request)
-        self.assertIn("delete_selected", actions)
+        self.assertIn("remove_selected", actions)
 
         # user2 won't be able to delete requests, as they are not the collection
         # author

--- a/tests/test_admin_actions.py
+++ b/tests/test_admin_actions.py
@@ -1009,7 +1009,7 @@ class DeleteSelectedTest(CMSTestCase):
         # Login as the collection author
         self.client.force_login(self.user)
         # Choose the delete_selected action from the dropdown
-        data = get_url_data(self, "delete_selected")
+        data = get_url_data(self, "remove_selected")
         response = self.client.post(self.url, data)
 
         self.assertEqual(response.status_code, 403)
@@ -1049,7 +1049,7 @@ class DeleteSelectedTest(CMSTestCase):
         # Login as the collection author
         self.client.force_login(self.user)
         # Choose the delete_selected action from the dropdown
-        data = get_url_data(self, "delete_selected")
+        data = get_url_data(self, "remove_selected")
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, 302)
 
@@ -1074,10 +1074,9 @@ class DeleteSelectedTest(CMSTestCase):
     def test_delete_view_when_using_get(self):
         # Login as the collection author
         self.client.force_login(self.user)
-        # Choose the delete_selected action from the dropdown
 
-        # Choose the approve_selected action from the dropdown
-        data = get_url_data(self, "delete_selected")
+        # Choose the delete_selected action from the dropdown
+        data = get_url_data(self, "remove_selected")
         response = self.client.post(self.url, data)
         # And follow the redirect (with a GET call) to the view that does the approve
         response = self.client.get(response.url)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,8 +2,8 @@ import json
 import mock
 from unittest import skip
 
-from django.urls import reverse
 from django.template.defaultfilters import truncatechars
+from django.urls import reverse
 
 from cms.test_utils.testcases import CMSTestCase
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -361,6 +361,7 @@ class ModerationRequestTest(BaseTestCase):
         self.wf2.compliance_number_backend = (
             "djangocms_moderation.backends.sequential_number_backend"
         )
+        self.wf2.save()
         request = ModerationRequest.objects.create(
             version=self.pg1_version,
             language="en",
@@ -378,6 +379,7 @@ class ModerationRequestTest(BaseTestCase):
     def test_compliance_number_sequential_number_with_identifier_prefix_backend(self):
         self.wf2.compliance_number_backend = "djangocms_moderation.backends.sequential_number_with_identifier_prefix_backend"  # noqa:E501
         self.wf2.identifier = "SSO"
+        self.wf2.save()
 
         request = ModerationRequest.objects.create(
             version=self.pg1_version,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -243,21 +243,21 @@ class CollectionItemsViewAddingRequestsTestCase(CMSTestCase):
         )
         self.assertEqual(mr.count(), 1)
         self.assertEqual(
-            ModerationRequestTreeNode.objects.filter(moderation_request=mr).count(), 1
+            ModerationRequestTreeNode.objects.filter(moderation_request=mr.first()).count(), 1
         )
         mr1 = ModerationRequest.objects.filter(
             collection=collection, version=poll1_version
         )
         self.assertEqual(mr1.count(), 1)
         self.assertEqual(
-            ModerationRequestTreeNode.objects.filter(moderation_request=mr1).count(), 1
+            ModerationRequestTreeNode.objects.filter(moderation_request=mr1.first()).count(), 1
         )
         mr2 = ModerationRequest.objects.filter(
             collection=collection, version=poll2_version
         )
         self.assertEqual(mr2.count(), 1)
         self.assertEqual(
-            ModerationRequestTreeNode.objects.filter(moderation_request=mr2).count(), 1
+            ModerationRequestTreeNode.objects.filter(moderation_request=mr2.first()).count(), 1
         )
 
     def test_add_pages_moderated_duplicated_children_to_collection(self):
@@ -540,14 +540,14 @@ class CollectionItemsViewAddingRequestsTestCase(CMSTestCase):
         )
         self.assertEqual(mr.count(), 1)
         self.assertEqual(
-            ModerationRequestTreeNode.objects.filter(moderation_request=mr).count(), 1
+            ModerationRequestTreeNode.objects.filter(moderation_request=mr.first()).count(), 1
         )
         mr1 = ModerationRequest.objects.filter(
             collection=collection, version=poll1_version
         )
         self.assertEqual(mr1.count(), 0)
         self.assertEqual(
-            ModerationRequestTreeNode.objects.filter(moderation_request=mr1).count(), 0
+            ModerationRequestTreeNode.objects.filter(moderation_request=mr1.first()).count(), 0
         )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 envlist =
     flake8
     isort
-    py{34,35,36}-dj111-sqlite-cms4
-    py{34,35,36}-dj20-sqlite-cms4
+    py{35,36}-dj{111,20,21,22}-sqlite-cms4
 
 skip_missing_interpreters=True
 
@@ -13,11 +12,12 @@ deps =
 
     dj111: Django>=1.11,<2.0
     dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
+    dj22: Django>=2.2,<3.0
 
     cms4: https://github.com/divio/django-cms/archive/release/4.0.x.zip
 
 basepython =
-    py34: python3.4
     py35: python3.5
     py36: python3.6
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     flake8
     isort
-    py{35,36}-dj{111,20,21,22}-sqlite-cms4
+    py{35,36}-dj{111,20}-sqlite-cms4-aldrynforms4
+    py{35,36}-dj{21,22}-sqlite-cms4-aldrynforms5
 
 skip_missing_interpreters=True
 
@@ -16,6 +17,8 @@ deps =
     dj22: Django>=2.2,<3.0
 
     cms4: https://github.com/divio/django-cms/archive/release/4.0.x.zip
+    aldrynforms5: https://github.com/divio/aldryn-forms/archive/master.zip
+    aldrynforms4: aldryn-forms==4.0.1
 
 basepython =
     py35: python3.5

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     flake8
     isort
-    py{35,36}-dj{111,20}-sqlite-cms4-aldrynforms4
-    py{35,36}-dj{21,22}-sqlite-cms4-aldrynforms5
+    py{35,36,37}-dj{111,20}-sqlite-cms4-aldrynforms4
+    py{35,36,37}-dj{21,22}-sqlite-cms4-aldrynforms5
 
 skip_missing_interpreters=True
 
@@ -23,6 +23,7 @@ deps =
 basepython =
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 
 commands =
     {envpython} --version


### PR DESCRIPTION
Depends on:
- https://github.com/FidelityInternational/djangocms-version-locking/pull/59
- https://github.com/divio/djangocms-versioning/pull/199

Issues with failing tests that need to be fixed first. 

The delete_selected action was changed in 2.2 so the decision was made to create a custom action for delete.

```
ERRORS:
<class 'djangocms_moderation.admin.ModerationRequestTreeAdmin'>: 
(admin.E130) __name__ attributes of actions defined in 
<class 'djangocms_moderation.admin.ModerationRequestTreeAdmin'> must be unique.
```