### PR TITLE
Referer error occuring in dj2.2

### DIFF
--- a/djangocms_moderation/admin_actions.py
+++ b/djangocms_moderation/admin_actions.py
@@ -148,14 +148,14 @@ def add_items_to_collection(modeladmin, request, queryset):
                 args=(),
             ),
             version_ids=",".join(version_ids),
-            return_to_url=request.META.get("HTTP_REFERER"),
+            return_to_url=request.META.get("HTTP_REFERER", ""),
         )
         return HttpResponseRedirect(admin_url)
     else:
         modeladmin.message_user(
             request, _("No suitable items found to add to moderation collection")
         )
-        return HttpResponseRedirect(request.META.get("HTTP_REFERER"))
+        return HttpResponseRedirect(request.META.get("HTTP_REFERER", ""))
 
 
 add_items_to_collection.short_description = _("Add to moderation collection")


### PR DESCRIPTION
Fixing the following error. 

```
File "/Users/jonathan/projects/eu-multisite-4/addons-dev/djangocms-versioning-filer/venv/lib/python3.6/site-packages/django/utils/http.py", line 96, in urlencode
    'Cannot encode None in a query string. Did you mean to pass '
TypeError: Cannot encode None in a query string. Did you mean to pass an empty string or omit the value?
```

Caught by tests here -> https://github.com/divio/djangocms-versioning-filer/pull/56