### PR TITLE
Added test case and validation for xss possibility in views

### DIFF
--- a/djangocms_moderation/views.py
+++ b/djangocms_moderation/views.py
@@ -6,7 +6,7 @@ from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.http import is_safe_url
+from django.utils.http import is_safe_url, urlquote
 from django.utils.translation import ugettext_lazy as _, ungettext
 from django.views.generic import FormView
 
@@ -88,6 +88,7 @@ class CollectionItemsView(FormView):
                 allowed_hosts=self.request.get_host(),
                 require_https=self.request.is_secure(),
             )
+            return_to_url = urlquote(return_to_url)
             if not url_is_safe:
                 return_to_url = self.request.path
             return HttpResponseRedirect(return_to_url)


### PR DESCRIPTION
Moderation views allowed query string parameters to be passed on to redirect without sanitisation, this PR is the fix and test case for it. 